### PR TITLE
No constants.ENOENT

### DIFF
--- a/lib/dirty/dirty.js
+++ b/lib/dirty/dirty.js
@@ -2,8 +2,7 @@ if (global.GENTLY) require = GENTLY.hijack(require);
 
 var fs = require('fs'),
     sys = require('sys'),
-    EventEmitter = require('events').EventEmitter,
-    constants = require('constants');
+    EventEmitter = require('events').EventEmitter;
 
 var Dirty = exports.Dirty = function(path) {
   if (!(this instanceof Dirty)) return new Dirty(path);
@@ -70,7 +69,7 @@ Dirty.prototype._load = function() {
 
   this._readStream
     .on('error', function(err) {
-      if (err.errno == constants.ENOENT) {
+      if (err.errno == process.binding('net').ENOENT) {
         self.emit('load', 0);
         return;
       }

--- a/test/simple/test-dirty.js
+++ b/test/simple/test-dirty.js
@@ -2,7 +2,6 @@ require('../common');
 var Dirty = require('dirty'),
     EventEmitter = require('events').EventEmitter,
     dirtyLoad = Dirty.prototype._load,
-    constants = require('constants'),
     gently,
     dirty;
 
@@ -182,7 +181,7 @@ test(function _load() {
         assert.equal(event, 'load');
         assert.equal(length, 0);
       });
-      readStreamEmit.error({errno: constants.ENOENT})
+      readStreamEmit.error({errno: process.binding('net').ENOENT})
     })();
   })();
 });


### PR DESCRIPTION
Unless I am missing something, there is no constants module in node 2.1/2.2 or in npm.  When I tried running a dirty DB, I got the following stacktrace:

```
Error: Cannot find module 'constants'
at loadModule (node.js:275:15)
at require (node.js:411:14)
at Object.<anonymous> (/home/cstrom/.node_libraries/.npm/dirty/0.9.0/package/lib/dirty/dirty.js:6:17)
at Module._compile (node.js:462:23)
at Module._loadScriptSync (node.js:469:10)
at Module.loadSync (node.js:338:12)
at loadModule (node.js:283:14)
at require (node.js:411:14)
at Object.<anonymous> (/home/cstrom/.node_libraries/.npm/dirty/0.9.0/package/lib/dirty/index.js:1:80)
at Module._compile (node.js:462:23)
```

It seems like process.binding('net') is the only place to get at ENOENT now, so this patch uses that.
