### PR TITLE
Check for correct error codes

### DIFF
--- a/lib/dirty/dirty.js
+++ b/lib/dirty/dirty.js
@@ -77,7 +77,7 @@ Dirty.prototype._load = function() {
 
   this._readStream
     .on('error', function(err) {
-      if (err.errno == process.binding('net').ENOENT) {
+      if (err.code === 'ENOENT') {
         self.emit('load', 0);
         return;
       }

--- a/test/simple/test-dirty.js
+++ b/test/simple/test-dirty.js
@@ -181,7 +181,7 @@ test(function _load() {
         assert.equal(event, 'load');
         assert.equal(length, 0);
       });
-      readStreamEmit.error({errno: process.binding('net').ENOENT})
+      readStreamEmit.error({ code: 'ENOENT' })
     })();
   })();
 });


### PR DESCRIPTION
node 0.4.x doesn't have `process.binding('net').ENOENT` anymore.
