### PR TITLE
Improved text file reading performance on long lines

### DIFF
--- a/lib/dirty/dirty.js
+++ b/lib/dirty/dirty.js
@@ -86,7 +86,14 @@ Dirty.prototype._load = function() {
     })
     .on('data', function(chunk) {
       buffer += chunk;
-      buffer = buffer.replace(/([^\n]+)\n/g, function(m, rowStr) {
+      if (chunk.lastIndexOf('\n') == -1) return;
+      var arr = buffer.split('\n');
+      buffer = arr.pop();
+      arr.forEach(function(rowStr) {
+        if (!rowStr) {
+          self.emit('error', new Error('Empty lines never appear in a healthy database'));
+          return
+        }
         try {
           var row = JSON.parse(rowStr);
           if (!('key' in row)) {


### PR DESCRIPTION
Before this patch Dirty took about 1 second to parse each '\n' line separator (!) of dirty db with 45KB lines during loading.
