### PR TITLE
add dirty db close function which closes file handles.

### DIFF
--- a/lib/dirty/dirty.js
+++ b/lib/dirty/dirty.js
@@ -21,6 +21,8 @@ var Dirty = exports.Dirty = function(path) {
   this._queue = [];
   this._readStream = null;
   this._writeStream = null;
+  this._fdRead = null;
+  this._fdWrite = null;
 
   this._load();
 };
@@ -92,9 +94,20 @@ Dirty.prototype.forEach = function(fn) {
 
 };
 
-
-
-
+/**
+ * Close dirty db file stream, release file handle
+ */
+Dirty.prototype.close = function() {
+	this._maybeFlush();
+	
+	var self = this;
+	fs.close(this._fdRead, function() {
+		self.emit('read_close', 0);
+	});
+	fs.close(this._fdWrite, function() {
+		self.emit('write_close', 0);
+	});
+};
 
 // Called when a dirty connection is instantiated
 Dirty.prototype._load = function() {
@@ -163,6 +176,9 @@ Dirty.prototype._load = function() {
         self.emit('error', new Error('Corrupted row at the end of the db: '+buffer));
       }
       self.emit('load', length);
+    })
+    .on('open', function(fd) {
+    	self._fdRead = fd;
     });
 
   this._writeStream = fs.createWriteStream(this.path, {
@@ -172,6 +188,10 @@ Dirty.prototype._load = function() {
 
   this._writeStream.on('drain', function() {
     self._writeDrain();
+  });
+  
+  this._writeStream.on('open', function(fd) {
+	  self._fdWrite = fd;
   });
 };
 


### PR DESCRIPTION
I made the service by the etherpad.
So I custermized etherpad to each pad use dirty db.
Each pad is used to separate dirty db, dirty db needed to close.
So close function has been added to dirty db.
