### PR TITLE
Added the ability to chain an .on('load') on the constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ records before this event fires. Writing records however should be fine.
 `length` is the amount of records the database is holding. This only counts each
 key once, even if it had been overwritten.
 
+You can chain the on load to the contructor as follows:
+
+```javascript
+var db = dirty(file).on('load', function() { ... });
+```
+
 ### dirty event: 'drain' ()
 
 Emitted whenever all records have been written to disk.

--- a/lib/dirty/dirty.js
+++ b/lib/dirty/dirty.js
@@ -25,6 +25,7 @@ var Dirty = exports.Dirty = function(path) {
   this._fdWrite = null;
 
   this._load();
+  return this;
 };
 
 util.inherits(Dirty, EventEmitter);

--- a/test/test-system.js
+++ b/test/test-system.js
@@ -97,3 +97,22 @@ describe('test-size', function() {
     assert.equal(db.size(), 3);
   });
 });
+
+describe('test-chaining-of-constructor', function() {
+  var file = config.TMP_PATH + '/chain.dirty';
+  fs.existsSync(file) && fs.unlinkSync(file);
+
+  it('should allow .on load to chain to constructor', function() {
+    var db = dirty(file);
+    db.on('load', function() {
+      db.set("x", "y");
+      db.set("p", "q");
+      db.close();
+
+      db = dirty(file).on('load', function(size) {
+        assert.strictEqual(db.size(), 2);  
+        assert.strictEqual(size, 2);  
+      });
+    });
+  });
+});


### PR DESCRIPTION
With this change you can chain the on-load event at the time of construction. .e.,g var db = dirty(file).on('load', ...);
