### PR TITLE
Fixed duplicate keys

### DIFF
--- a/lib/dirty/dirty.js
+++ b/lib/dirty/dirty.js
@@ -173,7 +173,9 @@ Dirty.prototype._load = function() {
           delete self._docs[row.key];
         } else {
           if (!(row.key in self._docs)) {
-            self._keys.push(row.key);
+            if(self._keys.indexOf(row.key) === -1){
+            	self._keys.push(row.key);
+            }
             length++;
           }
           self._docs[row.key] = row.val;


### PR DESCRIPTION
Fix for tis bug:

```
$ cat test.db 
{"key":"k","val":"v1"}
{"key":"k"}
{"key":"k","val":"v2"}
```

``` javascript
$ cat app.js 
var db = require('dirty')('test.db').on('load', function() {
  db.forEach(console.log);
});
```

```
$ node app.js 
k v2
k v2
```
