### PR TITLE
Update TravisCI to modern versions of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
+  - "stable"
+  - "5"
+  - "4"
   - "0.10"
-  - "0.8"  


### PR DESCRIPTION
While "stable" is the same as "5" for now, it won't be forever.

I wasn't sure whether I should remove "0.8" or not...