### PR TITLE
Various changes to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dirty",
   "description": "A tiny & fast key value store with append-only disk log. Ideal for apps with < 1 million records.",
   "version": "1.0.0",
+  "repository": "https://github.com/felixge/node-dirty.git",
   "dependencies": {},
   "main": "./lib/dirty",
   "devDependencies": {
@@ -9,9 +10,6 @@
     "rimraf": "~2.1.4"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha test/test-*.js -R list"
-  },
-  "engines": {
-    "node": "*"
+    "test": "mocha test/test-*.js -R list"
   }
 }


### PR DESCRIPTION
1. Just reference 'mocha' instead of the path to 'mocha' in the test script.
2. Add a link to the felixge/node-dirty git repo to squelch a warning.
3. Remove the deprecated 'engines' field.